### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/pradiravi0275/93784d52-363a-4426-9100-a952b6a4ff55/188713d7-6f66-4cd0-bed4-857719fcd3f2/_apis/work/boardbadge/82a5e8e7-68c5-4dc0-953a-a60262f53bd3)](https://dev.azure.com/pradiravi0275/93784d52-363a-4426-9100-a952b6a4ff55/_boards/board/t/188713d7-6f66-4cd0-bed4-857719fcd3f2/Microsoft.FeatureCategory)
 # java-maven-app
 
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://dev.azure.com/pradiravi0275/93784d52-363a-4426-9100-a952b6a4ff55/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.